### PR TITLE
fix(docs): Disable creation of PDF and ePub documentation files

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,10 +9,6 @@ sphinx:
   fail_on_warning: true
   configuration: docs/source/conf.py
 
-formats:
-  - pdf
-  - epub
-
 python:
   # Install our python package before building the docs
   install:


### PR DESCRIPTION
Integrating batches from shields.io is causing some trouble with respect to rendering of SVG files. Therefore, these options have been disabled.