### PR TITLE
docs: Fix dead link to CHANGELOG

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -323,7 +323,7 @@ contributors should adhere to the following points (not exhaustive):
 
 This project follows the [Conventional Commits](https://www.conventionalcommits.org/)
 specification. This will help us to automatically generate the
-[CHANGELOG](../CHANGELOG).
+[CHANGELOG](../changelog).
 
 ## Attribution
 This guide is based on the **contributing-gen**.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,7 +8,11 @@ You can install the package via ``pip``.
 pip install df2img
 ```
 
-You can also use ``poetry``.
+You can also use ``pdm`` or ``poetry``.
+
+```bash
+pdm add df2img
+```
 
 ```bash
 poetry add df2img


### PR DESCRIPTION
Referring page: https://df2img.dev/contributing/
Target page: https://df2img.dev/CHANGELOG

The target link has been changed to https://df2img.dev/changelog

Closes #59